### PR TITLE
explicitly set envdir on startup

### DIFF
--- a/lib/Test/WWW/Mechanize/Dancer.pm
+++ b/lib/Test/WWW/Mechanize/Dancer.pm
@@ -52,7 +52,9 @@ has mech        => (
     use Test::WWW::Mechanize::Dancer;
 
     # Get your standard Test::WWW::Mechanize object
-    my $mech = Test::WWW::Mechanize::Dancer->new->mech;
+    my $mech = Test::WWW::Mechanize::Dancer->new(
+        # settings here if required
+    )->mech;
     # Run standard Test::WWW::Mechanize tests
     $mech->get_ok('/');
 

--- a/lib/Test/WWW/Mechanize/Dancer.pm
+++ b/lib/Test/WWW/Mechanize/Dancer.pm
@@ -9,6 +9,7 @@ use Test::WWW::Mechanize::PSGI;
 # VERSION
 
 has appdir      => (is => 'ro', default => getcwd );
+has envdir      => (is => 'ro');
 has agent       => (is => 'ro', default => 'Dancer Tests');
 has confdir     => (is => 'ro');
 has environment => (is => 'ro', default => 'test');
@@ -26,6 +27,7 @@ has mech        => (
                 my $env = shift;
                 set (
                     appdir => $self->appdir,
+                    envdir => $self->envdir || path($self->appdir, 'environments'),
                     confdir => $self->confdir || $self->appdir,
                     public => $self->public || $self->appdir . '/public',
                     views => $self->views || $self->appdir . '/views',
@@ -78,6 +80,13 @@ Allows you to set the user agent of the Mechanizer.
 =head2 confdir
 
 Set the dancer confdir.  Will default to appdir if unspecified.
+
+=head2 envdir
+
+Allows you to set the directory where Dancer should look for the config files
+for each environment.  Defaults to 'environments' under appdir.  Note if your
+app uses $ENV{DANCER_ENVDIR} you should explicitly pass that value using this
+option.
 
 =head2 environment
 


### PR DESCRIPTION
I found that this patch fixed the problem that my test.yml config file was not being loaded.

It turns out that the appdir setting inside of Dancer gets set twice - once when Dancer is first loaded and later it is explicitly set by Test::WWW::Mechanize::Dancer.  The first time it is set, Dancer calculates a path based on the location of Test/WWW/Mechanize/Dancer.pm so for me it ended up as /home/grant/perl5/lib/perl5/Test/WWW/Mechanize - which is not very useful.  Some short time later, it was overwritten with the much more sensible default of the current working directory.

The problem with all of that is that Dancer was using the appdir setting to initialise envdir and this was happening after appdir was set to the initial useless value and before it was set to the current working directory.

Which is all a long way of saying that I added the envdir option not because I wanted to use a non-default value, but because I wanted the envdir setting to be updated after appdir was changed. 
