### PR TITLE
Dancer's load DSL keyword causes prototype conflict with Module::Load

### DIFF
--- a/lib/Test/WWW/Mechanize/Dancer.pm
+++ b/lib/Test/WWW/Mechanize/Dancer.pm
@@ -2,7 +2,7 @@ package Test::WWW::Mechanize::Dancer;
 use strict;
 use warnings;
 use Cwd;
-use Dancer qw(:tests :moose);
+use Dancer qw(:tests :moose !load);
 use Module::Load qw(load);
 use Moose;
 use Test::WWW::Mechanize::PSGI;


### PR DESCRIPTION
Hi,

The load keyword is now exported by default by Dancer, so it causes a prototype mismatch when I use this Test::WWW::Machanize.

Here is an example warning:

```
Prototype mismatch: sub Test::WWW::Mechanize::Dancer::load: none vs (*;@) at /Library/Perl/5.16/Module/Load.pm line 29.
```

This change fixes the problem by no longer allowing load from Dancer to be exported.

Thanks,

Rusty
